### PR TITLE
Fix cumulative-metric aggregation: SUM instead of AVG, skip read-side dedup

### DIFF
--- a/server/internal/storage/health_metrics.go
+++ b/server/internal/storage/health_metrics.go
@@ -279,17 +279,32 @@ type MetricStats struct {
 	Count  int64    `json:"count"`
 }
 
-// GetMetricStats returns aggregate statistics for a metric over a time range.
-func (db *DB) GetMetricStats(ctx context.Context, metricName string, start, end time.Time, userID int) (*MetricStats, error) {
-	priorities := db.ResolveSourcePriorityForMetric(ctx, userID, metricName)
+// buildMetricStatsQuery returns the SQL for GetMetricStats. For cumulative
+// metrics (e.g. step_count, active_energy) the headline aggregate is SUM over
+// the range; for all others it is AVG. MIN/MAX/STDDEV/COUNT are unchanged
+// (still useful for cumulative — e.g. max single-bin value, sample count).
+// Mirrors the cumulativeMetrics branching already used by GetTimeSeries and
+// GetCorrelation.
+func buildMetricStatsQuery(metricName string, priorities []string) string {
+	agg := "AVG"
+	if cumulativeMetrics[metricName] {
+		agg = "SUM"
+	}
 	cte := dedupCTE(priorities, "$1", "$2", "$3", "$4")
-	query := fmt.Sprintf(
-		`%sSELECT AVG(COALESCE(qty, avg_val)),
+	return fmt.Sprintf(
+		`%sSELECT %s(COALESCE(qty, avg_val)),
 		        MIN(COALESCE(qty, min_val)),
 		        MAX(COALESCE(qty, max_val)),
 		        STDDEV_POP(COALESCE(qty, avg_val)),
 		        COUNT(*)
-		 FROM deduped WHERE rn = 1`, cte)
+		 FROM deduped WHERE rn = 1`, cte, agg)
+}
+
+// GetMetricStats returns aggregate statistics for a metric over a time range.
+// The "avg" field holds a SUM for cumulative metrics; see buildMetricStatsQuery.
+func (db *DB) GetMetricStats(ctx context.Context, metricName string, start, end time.Time, userID int) (*MetricStats, error) {
+	priorities := db.ResolveSourcePriorityForMetric(ctx, userID, metricName)
+	query := buildMetricStatsQuery(metricName, priorities)
 	row := db.Pool.QueryRow(ctx, query, metricName, start, end, userID)
 
 	stats := &MetricStats{Metric: metricName}

--- a/server/internal/storage/health_metrics.go
+++ b/server/internal/storage/health_metrics.go
@@ -37,7 +37,23 @@ func sourcePriorityCaseSQL(priorities []string) string {
 // 5-minute granularity using source priority. The CTE selects all columns plus
 // a row number (rn) partitioned by 5-minute time buckets. Callers should filter
 // with "WHERE rn = 1" to keep only the highest-priority source per bucket.
-func dedupCTE(priorities []string, metricParam, startParam, endParam, userIDParam string) string {
+//
+// If isCumulative is true, the CTE emits a constant rn=1 instead of an actual
+// ROW_NUMBER, so callers' "WHERE rn = 1" predicate is a no-op and every row is
+// retained. The 5-minute dedup is intended for cross-source contention (Oura
+// vs Apple Watch vs HAE on the same wrist-moment); for cumulative metrics like
+// step_count, HAE emits per-second rate samples (~11K rows/day) that all
+// legitimately stack inside the same 5-minute bucket. Filtering rn=1 would
+// drop ~99% of them and collapse daily totals to ~1% of reality.
+func dedupCTE(priorities []string, metricParam, startParam, endParam, userIDParam string, isCumulative bool) string {
+	if isCumulative {
+		return fmt.Sprintf(
+			`WITH deduped AS (
+				SELECT *, 1 AS rn
+				FROM health_metrics
+				WHERE metric_name = %s AND time >= %s AND time < %s AND user_id = %s
+			) `, metricParam, startParam, endParam, userIDParam)
+	}
 	priorityExpr := sourcePriorityCaseSQL(priorities)
 	return fmt.Sprintf(
 		`WITH deduped AS (
@@ -176,7 +192,7 @@ func (db *DB) GetTimeSeries(ctx context.Context, metricName string, start, end t
 		aggFunc = "SUM"
 	}
 	priorities := db.ResolveSourcePriorityForMetric(ctx, userID, metricName)
-	cte := dedupCTE(priorities, "$2", "$3", "$4", "$5")
+	cte := dedupCTE(priorities, "$2", "$3", "$4", "$5", cumulativeMetrics[metricName])
 	query := fmt.Sprintf(
 		`%sSELECT time_bucket($1::interval, time) AS bucket,
 		        %s(COALESCE(qty, avg_val)) AS avg_val,
@@ -290,7 +306,7 @@ func buildMetricStatsQuery(metricName string, priorities []string) string {
 	if cumulativeMetrics[metricName] {
 		agg = "SUM"
 	}
-	cte := dedupCTE(priorities, "$1", "$2", "$3", "$4")
+	cte := dedupCTE(priorities, "$1", "$2", "$3", "$4", cumulativeMetrics[metricName])
 	return fmt.Sprintf(
 		`%sSELECT %s(COALESCE(qty, avg_val)),
 		        MIN(COALESCE(qty, min_val)),
@@ -342,19 +358,24 @@ func (db *DB) GetCorrelation(ctx context.Context, xMetric, yMetric string, start
 	// For correlation, use the priority for the X metric's category.
 	priorities := db.ResolveSourcePriorityForMetric(ctx, userID, xMetric)
 	priorityExpr := sourcePriorityCaseSQL(priorities)
+	// For cumulative metrics, skip the 5-minute dedup ROW_NUMBER (emit constant
+	// rn=1) so high-frequency single-source samples are not collapsed. See
+	// dedupCTE for the full rationale.
+	xRnExpr := fmt.Sprintf("ROW_NUMBER() OVER (PARTITION BY time_bucket('5 minutes', time) ORDER BY %s)", priorityExpr)
+	if cumulativeMetrics[xMetric] {
+		xRnExpr = "1"
+	}
+	yRnExpr := fmt.Sprintf("ROW_NUMBER() OVER (PARTITION BY time_bucket('5 minutes', time) ORDER BY %s)", priorityExpr)
+	if cumulativeMetrics[yMetric] {
+		yRnExpr = "1"
+	}
 	query := fmt.Sprintf(
 		`WITH x_deduped AS (
-			SELECT *, ROW_NUMBER() OVER (
-				PARTITION BY time_bucket('5 minutes', time)
-				ORDER BY %s
-			) AS rn
+			SELECT *, %s AS rn
 			FROM health_metrics
 			WHERE metric_name = $2 AND time >= $4 AND time < $5 AND user_id = $6
 		), y_deduped AS (
-			SELECT *, ROW_NUMBER() OVER (
-				PARTITION BY time_bucket('5 minutes', time)
-				ORDER BY %s
-			) AS rn
+			SELECT *, %s AS rn
 			FROM health_metrics
 			WHERE metric_name = $3 AND time >= $4 AND time < $5 AND user_id = $6
 		), x AS (
@@ -370,7 +391,7 @@ func (db *DB) GetCorrelation(ctx context.Context, xMetric, yMetric string, start
 		)
 		SELECT x.bucket, x.val, y.val
 		FROM x JOIN y ON x.bucket = y.bucket
-		ORDER BY x.bucket ASC`, priorityExpr, priorityExpr, xAgg, yAgg)
+		ORDER BY x.bucket ASC`, xRnExpr, yRnExpr, xAgg, yAgg)
 	rows, err := db.Pool.Query(ctx, query,
 		bucket, xMetric, yMetric, start, end, userID)
 	if err != nil {

--- a/server/internal/storage/health_metrics_test.go
+++ b/server/internal/storage/health_metrics_test.go
@@ -70,6 +70,67 @@ func TestDedupCTE(t *testing.T) {
 	}
 }
 
+// TestBuildMetricStatsQueryCumulative verifies that GetMetricStats uses SUM
+// for cumulative metrics (step_count, active_energy, distance_*, etc.) instead
+// of AVG. HAE emits per-second rate samples for these, so AVG over a day
+// returns the wrong value (e.g. ~0.6 instead of ~3215 for step_count).
+func TestBuildMetricStatsQueryCumulative(t *testing.T) {
+	cumulative := []string{
+		"step_count",
+		"active_energy",
+		"basal_energy_burned",
+		"apple_exercise_time",
+		"apple_move_time",
+		"apple_stand_time",
+		"flights_climbed",
+		"push_count",
+		"swimming_stroke_count",
+		"distance_walking_running",
+		"distance_cycling",
+		"distance_swimming",
+		"distance_wheelchair",
+		"distance_downhill_snow_sports",
+	}
+	for _, metric := range cumulative {
+		t.Run(metric, func(t *testing.T) {
+			sql := buildMetricStatsQuery(metric, nil)
+			if !strings.Contains(sql, "SUM(COALESCE(qty, avg_val))") {
+				t.Errorf("expected SUM aggregate for cumulative metric %q, got:\n%s", metric, sql)
+			}
+			if strings.Contains(sql, "AVG(COALESCE(qty, avg_val))") {
+				t.Errorf("did not expect AVG aggregate for cumulative metric %q, got:\n%s", metric, sql)
+			}
+			// MIN/MAX/STDDEV/COUNT are still emitted unchanged.
+			for _, want := range []string{
+				"MIN(COALESCE(qty, min_val))",
+				"MAX(COALESCE(qty, max_val))",
+				"STDDEV_POP(COALESCE(qty, avg_val))",
+				"COUNT(*)",
+			} {
+				if !strings.Contains(sql, want) {
+					t.Errorf("expected %q in stats query for %q, got:\n%s", want, metric, sql)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildMetricStatsQueryNonCumulative verifies that non-cumulative metrics
+// (heart_rate, body_mass, etc.) still use AVG as before.
+func TestBuildMetricStatsQueryNonCumulative(t *testing.T) {
+	for _, metric := range []string{"heart_rate", "body_mass", "blood_pressure_systolic", "respiratory_rate"} {
+		t.Run(metric, func(t *testing.T) {
+			sql := buildMetricStatsQuery(metric, nil)
+			if !strings.Contains(sql, "AVG(COALESCE(qty, avg_val))") {
+				t.Errorf("expected AVG aggregate for non-cumulative metric %q, got:\n%s", metric, sql)
+			}
+			if strings.Contains(sql, "SUM(COALESCE(qty, avg_val))") {
+				t.Errorf("did not expect SUM aggregate for non-cumulative metric %q, got:\n%s", metric, sql)
+			}
+		})
+	}
+}
+
 // TestDedupCTEMultiMetric verifies the multi-metric CTE partitions by both
 // metric_name and time bucket, preventing cross-metric deduplication.
 func TestDedupCTEMultiMetric(t *testing.T) {

--- a/server/internal/storage/health_metrics_test.go
+++ b/server/internal/storage/health_metrics_test.go
@@ -49,7 +49,7 @@ func TestSourcePriorityCaseSQL(t *testing.T) {
 // TestDedupCTE verifies that the generated CTE has the correct structure:
 // a WITH clause using time_bucket, ROW_NUMBER, and the right parameter placeholders.
 func TestDedupCTE(t *testing.T) {
-	cte := dedupCTE([]string{"Oura", ""}, "$2", "$3", "$4", "$5")
+	cte := dedupCTE([]string{"Oura", ""}, "$2", "$3", "$4", "$5", false)
 
 	checks := []string{
 		"WITH deduped AS",
@@ -128,6 +128,67 @@ func TestBuildMetricStatsQueryNonCumulative(t *testing.T) {
 				t.Errorf("did not expect SUM aggregate for non-cumulative metric %q, got:\n%s", metric, sql)
 			}
 		})
+	}
+}
+
+// TestBuildMetricStatsQueryCumulativeSkipsDedup verifies that for cumulative
+// metrics the generated stats query does NOT include the ROW_NUMBER-based
+// 5-minute dedup. HAE emits ~11K per-second rate samples for step_count in a
+// single day; filtering by ROW_NUMBER()=1 across 5-minute buckets would drop
+// ~99% of them and collapse the daily total to ~1% of reality. The 5-minute
+// dedup exists to break ties between competing sources (Oura/Apple/HAE) on
+// the same wrist-moment, not to thin out high-frequency single-source streams.
+func TestBuildMetricStatsQueryCumulativeSkipsDedup(t *testing.T) {
+	for _, metric := range []string{"step_count", "active_energy", "distance_walking_running", "flights_climbed"} {
+		t.Run(metric, func(t *testing.T) {
+			sql := buildMetricStatsQuery(metric, []string{"Oura", ""})
+			if strings.Contains(sql, "ROW_NUMBER()") {
+				t.Errorf("expected no ROW_NUMBER() dedup for cumulative metric %q, got:\n%s", metric, sql)
+			}
+			if strings.Contains(sql, "PARTITION BY time_bucket") {
+				t.Errorf("expected no time_bucket partition for cumulative metric %q, got:\n%s", metric, sql)
+			}
+			// CTE should still be present and emit a constant rn so the
+			// caller's WHERE rn = 1 predicate is a no-op.
+			if !strings.Contains(sql, "1 AS rn") {
+				t.Errorf("expected '1 AS rn' constant in CTE for cumulative metric %q, got:\n%s", metric, sql)
+			}
+		})
+	}
+}
+
+// TestBuildMetricStatsQueryNonCumulativeKeepsDedup verifies that non-cumulative
+// metrics still get the 5-minute ROW_NUMBER dedup, which is needed when more
+// than one source reports the same wrist-moment (e.g. Oura vs Apple Watch
+// heart rate).
+func TestBuildMetricStatsQueryNonCumulativeKeepsDedup(t *testing.T) {
+	for _, metric := range []string{"heart_rate", "body_mass", "respiratory_rate", "blood_pressure_systolic"} {
+		t.Run(metric, func(t *testing.T) {
+			sql := buildMetricStatsQuery(metric, []string{"Oura", ""})
+			if !strings.Contains(sql, "ROW_NUMBER()") {
+				t.Errorf("expected ROW_NUMBER() dedup for non-cumulative metric %q, got:\n%s", metric, sql)
+			}
+			if !strings.Contains(sql, "PARTITION BY time_bucket('5 minutes', time)") {
+				t.Errorf("expected 5-minute time_bucket partition for non-cumulative metric %q, got:\n%s", metric, sql)
+			}
+		})
+	}
+}
+
+// TestDedupCTECumulativeFlag verifies the isCumulative flag swaps the CTE
+// body between the ROW_NUMBER form (false) and the constant-rn form (true).
+func TestDedupCTECumulativeFlag(t *testing.T) {
+	cumulativeCTE := dedupCTE([]string{"Oura", ""}, "$2", "$3", "$4", "$5", true)
+	if strings.Contains(cumulativeCTE, "ROW_NUMBER()") {
+		t.Errorf("isCumulative=true should not emit ROW_NUMBER, got:\n%s", cumulativeCTE)
+	}
+	if !strings.Contains(cumulativeCTE, "1 AS rn") {
+		t.Errorf("isCumulative=true should emit constant '1 AS rn', got:\n%s", cumulativeCTE)
+	}
+
+	normalCTE := dedupCTE([]string{"Oura", ""}, "$2", "$3", "$4", "$5", false)
+	if !strings.Contains(normalCTE, "ROW_NUMBER()") {
+		t.Errorf("isCumulative=false should emit ROW_NUMBER, got:\n%s", normalCTE)
 	}
 }
 


### PR DESCRIPTION
## What's wrong

`GetMetricStats` in `server/internal/storage/health_metrics.go` unconditionally uses `AVG(COALESCE(qty, avg_val))` as its headline aggregate. For cumulative metrics (step_count, active_energy, flights_climbed, all `distance_*`, `apple_exercise_time`, `apple_move_time`, `apple_stand_time`, `push_count`, `basal_energy_burned`, `swimming_stroke_count`, `distance_downhill_snow_sports`) this returns the wrong answer.

Concrete example: a day with ~3215 steps gets reported as `avg ≈ 0.6` (the per-second rate sample average) instead of `sum ≈ 3215` (the actual step count for the range).

## Why

Health Auto Export emits per-second rate samples for cumulative quantities. Averaging those samples answers "what's the average per-sample value" — which isn't a meaningful number for a counter. The correct headline aggregate over a time range is `SUM`.

## Existing correct pattern

The file already has a `cumulativeMetrics` map and uses it correctly in:

- `GetTimeSeries` (around line 174): switches the bucket aggregate between `SUM` and `AVG` based on `cumulativeMetrics[metricName]`.
- `GetCorrelation` (around line 319): same branching for `xMetric` / `yMetric`.

`GetMetricStats` was the outlier. This PR brings it in line by extracting the SQL build into `buildMetricStatsQuery` and branching on the same `cumulativeMetrics` map.

## Second fix: skip read-side dedup for cumulative metrics

After landing the SUM fix above, step totals were still ~1% of reality. The cause is the 5-minute dedup CTE (`dedupCTE`, lines ~40–50) used by every read path. It partitions by `time_bucket('5 minutes', time)` and keeps only `ROW_NUMBER() = 1`, which is the correct behavior when multiple competing sources (Oura vs Apple Watch vs HAE) report the same wrist-moment — but it silently collapses high-frequency single-source streams.

HAE emits ~11,633 per-second rate samples for `step_count` in a single day. The dedup keeps ~71 of them. Even with `SUM` running on the survivors, the daily total comes out at ~1% of reality, because the rows are gone before `SUM` ever sees them.

The fix: for metrics in `cumulativeMetrics`, the CTE now emits a constant `rn = 1` instead of a real `ROW_NUMBER`, so the existing `WHERE rn = 1` predicate in every caller becomes a no-op and every sample flows through. Non-cumulative metrics keep the original dedup since cross-source contention is still real for them.

Applied to `GetMetricStats` (via `buildMetricStatsQuery`), `GetTimeSeries`, and `GetCorrelation`. `GetDailySums` is left as-is: it queries multiple metrics at once with the `_default` priority and the dedup is still useful for the non-cumulative members of a multi-metric query. Splitting it per-metric is a possible follow-up.

## Scope of behavior change

Gated by metric name via the existing `cumulativeMetrics` map — behavior for all non-cumulative metrics (heart_rate, body_mass, blood pressure, respiratory rate, etc.) is byte-for-byte identical. `MIN` / `MAX` / `STDDEV_POP` / `COUNT` are unchanged for cumulative metrics too (still useful — e.g. max single-bin value, sample count).

## Tests

Added unit tests in `health_metrics_test.go` following the existing SQL-string inspection pattern:

- `TestBuildMetricStatsQueryCumulative` — asserts SUM is emitted for every metric in `cumulativeMetrics`, AVG is not.
- `TestBuildMetricStatsQueryNonCumulative` — asserts AVG is still emitted for heart_rate / body_mass / etc.
- `TestBuildMetricStatsQueryCumulativeSkipsDedup` — asserts the stats query for cumulative metrics contains no `ROW_NUMBER()` / `PARTITION BY time_bucket`, and emits the constant `1 AS rn` in the CTE.
- `TestBuildMetricStatsQueryNonCumulativeKeepsDedup` — asserts non-cumulative metrics still get the 5-minute `ROW_NUMBER` partition.
- `TestDedupCTECumulativeFlag` — direct unit test for the new `isCumulative` parameter on `dedupCTE`.

`go test ./internal/storage/...` passes. (Two unrelated top-level packages fail on `web.go: pattern all:web/dist: no matching files found` — that's a missing build artifact for the embedded web UI, present on `main` and unrelated to this change.)

## Follow-up

- The JSON field is still named `avg` in the `MetricStats` struct. For cumulative metrics that value is now a `sum`, which is slightly misleading. Renaming would be a breaking API change for any consumers, so I've left it; flagging as a follow-up rather than rolling it into this fix.
- `GetDailySums` still applies the dedup uniformly across all metrics in a single query; splitting per-metric (so cumulative members skip dedup while non-cumulative members keep it) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
